### PR TITLE
Add fields getter and method for iterating fields

### DIFF
--- a/docs/reference/Form.md
+++ b/docs/reference/Form.md
@@ -24,6 +24,14 @@ Note that the `onSubmit` callback may or may not return a promise, but the form 
 
 This means that, when submitting the form, you can opt to do something synchronously, or asynchronously; the latter is the most common option since a request is usually sent to a web service.
 
+### fields
+
+```ts
+fields: Record<string, Field<unknown>>
+```
+
+Returns an object where each key is the identifier of a field and the value is the field itself.
+
 ### values
 
 ```ts
@@ -164,6 +172,14 @@ select<T>( fieldKey: string ): T
 ```
 
 Alias of `field`.
+
+### eachField
+
+```ts
+eachField( actionOnField: ( field: Field<unknown> ) => void ): void
+```
+
+A method for looping through all fields. Executes the given callback for each of them.
 
 ### submit
 

--- a/src/Form/index.ts
+++ b/src/Form/index.ts
@@ -2,7 +2,7 @@ import {
 	action, computed, makeObservable, observable
 } from 'mobx';
 import {
-	every, forEach, pickBy, some
+	clone, every, forEach, pickBy, some
 } from 'lodash';
 import Field from '../Field';
 import type {
@@ -13,21 +13,22 @@ import type { ValueType } from '../utils/types';
 import deprecatedMethod from '../utils/deprecatedMethod';
 
 export default class Form {
-	private fields: FormFields;
+	private _fields: FormFields;
 	private submitAction: FormSubmitAction;
 	private _isSubmitting: boolean;
 
 	constructor( { fields, onSubmit = () => undefined }: FormParams ) {
-		this.fields = fields;
+		this._fields = fields;
 		this.submitAction = wrapInAsyncAction( onSubmit );
 		this._isSubmitting = false;
 
 		this.attachFields();
 
-		makeObservable<Form, 'fields' | 'submitAction' | '_isSubmitting' >( this, {
-			fields: observable,
+		makeObservable<Form, '_fields' | 'submitAction' | '_isSubmitting' >( this, {
+			_fields: observable,
 			submitAction: observable,
 			_isSubmitting: observable,
+			fields: computed,
 			values: computed,
 			dirtyValues: computed,
 			isValid: computed,
@@ -41,8 +42,12 @@ export default class Form {
 		} );
 	}
 
+	get fields(): FormFields {
+		return clone( this._fields );
+	}
+
 	get values(): FormValues {
-		return valuesOf( this.fields );
+		return valuesOf( this._fields );
 	}
 
 	get dirtyValues(): FormValues {
@@ -54,7 +59,7 @@ export default class Form {
 	}
 
 	get isDirty() {
-		return some( this.fields, field => field.isDirty );
+		return some( this._fields, field => field.isDirty );
 	}
 
 	get isReadyToSubmit() {
@@ -66,7 +71,7 @@ export default class Form {
 	}
 
 	field<FieldType extends Field<ValueType<FieldType>> = Field<unknown>>( fieldKey: string ) {
-		return this.fields[ fieldKey ] as FieldType;
+		return this._fields[ fieldKey ] as FieldType;
 	}
 
 	select<FieldType extends Field<ValueType<FieldType>> = Field<unknown>>( fieldKey: string ) {
@@ -75,6 +80,10 @@ export default class Form {
 		);
 
 		return this.field<FieldType>( fieldKey );
+	}
+
+	eachField( actionOnField: ( field: Field<unknown> ) => void ) {
+		forEach( this._fields, actionOnField );
 	}
 
 	submit(): Promise<void> {
@@ -97,7 +106,7 @@ export default class Form {
 	}
 
 	private attachFields() {
-		forEach( this.fields, field => field.attachToForm( this ) );
+		forEach( this._fields, field => field.attachToForm( this ) );
 	}
 
 	private get dirtyFields() {
@@ -109,11 +118,11 @@ export default class Form {
 	}
 
 	private pickFieldsBy( predicate: ( field: Field<unknown> ) => boolean ): FormFields {
-		return pickBy( this.fields, predicate );
+		return pickBy( this._fields, predicate );
 	}
 
 	private syncFieldErrors() {
-		forEach( this.fields, field => field.syncError() );
+		forEach( this._fields, field => field.syncError() );
 	}
 
 	private executeSubmitAction() {
@@ -123,12 +132,8 @@ export default class Form {
 			.finally( action( () => { this._isSubmitting = false; } ) );
 	}
 
-	private eachField( actionOnField: ( field: Field<unknown> ) => void ) {
-		forEach( this.fields, actionOnField );
-	}
-
 	private showErrorOnField( fieldKey: string, error: string ) {
-		this.fields[ fieldKey ]?.showError( error );
+		this._fields[ fieldKey ]?.showError( error );
 	}
 }
 

--- a/tests/Form.test.ts
+++ b/tests/Form.test.ts
@@ -92,6 +92,20 @@ describe( 'Form', () => {
 
 	afterEach( () => jest.clearAllMocks() );
 
+	describe( '@fields', () => {
+		it( 'returns an object with all the fields indexed by their keys', () => {
+			const form = createForm();
+
+			expect( form.fields ).toEqual( {
+				email: form.field( 'email' ),
+				password: form.field( 'password' ),
+				passwordConfirmation: form.field( 'passwordConfirmation' ),
+				document: form.field( 'document' ),
+				admin: form.field( 'admin' )
+			} );
+		} );
+	} );
+
 	describe( '@values', () => {
 		it( 'returns an object with values per field key', () => {
 			const form = createForm();
@@ -240,6 +254,21 @@ describe( 'Form', () => {
 			expect( documentField.label ).toEqual( 'Document' );
 			expect( documentField.value ).toEqual( 'unused' );
 			expect( documentField.isDisabled ).toBe( true );
+		} );
+	} );
+
+	describe( '@eachField', () => {
+		it( 'executes the given callback for each field', () => {
+			const form = createForm();
+			const fieldLabels: string[] = [];
+
+			form.eachField( ( field ) => {
+				fieldLabels.push( field.label );
+			} );
+
+			expect( fieldLabels ).toEqual(
+				Object.values( fields ).map( ( { label } ) => label )
+			);
 		} );
 	} );
 
@@ -394,10 +423,7 @@ describe( 'Form', () => {
 				document: 'This document failed the external validation'
 			};
 
-			form.showErrors( {
-				email: 'This email is being used',
-				document: 'This document failed the external validation'
-			} );
+			form.showErrors( errors );
 
 			expect( form.field( 'email' ).error ).toEqual( errors.email );
 			expect( form.field( 'document' ).error ).toEqual( errors.document );


### PR DESCRIPTION
Agrego el getter `fields` y el método `eachField` para loopear.

`fields` devuelve una shallow copy del objeto interno para que no se pueda romper el encapsulamiento agregándole fields o quitándoselos. También podría meterle un `Readonly< >` al tipo devuelto, pero sería una protección en tiempo de compilación únicamente (si la librería se usa con JS, o se hace alguna chanchada con TS para librarse del `Readonly`, esa protección no existe).