### PR TITLE
Export more types in main index.ts file

### DIFF
--- a/src/Form/index.ts
+++ b/src/Form/index.ts
@@ -132,4 +132,10 @@ export default class Form {
 	}
 }
 
-export type { FormParams, FormValues };
+export type {
+	FormFields,
+	FormParams,
+	FormSubmitAction,
+	FormSubmitCallback,
+	FormValues
+} from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,55 @@
 export {
-	default as config, configure, type Config, type ConfigOptions
+	default as config,
+	configure,
+	type Config,
+	type ConfigOptions
 } from './config';
-export { default as Field, type FieldParams, type FieldOnChangeCallback } from './Field';
+
+export {
+	default as Field,
+	type FieldParams,
+	type FieldOnChangeCallback
+} from './Field';
+
 export {
 	default as Input,
 	type InputParams,
 	type InputErrorDisplayConfig,
 	type InputCallback
 } from './Input';
-export { default as TextInput, textInput, type TextInputParams } from './TextInput';
-export { default as ManualField, manualField } from './ManualField';
-export { default as select, type Select, type SelectParams } from './select';
-export { default as multiSelect, type MultiSelect, type MultiSelectParams } from './multiSelect';
-export { default as Form, type FormParams, type FormValues } from './Form';
+
+export {
+	default as TextInput,
+	textInput,
+	type TextInputParams
+} from './TextInput';
+
+export {
+	default as ManualField,
+	manualField
+} from './ManualField';
+
+export {
+	default as select,
+	type Select,
+	type SelectParams
+} from './select';
+
+export {
+	default as multiSelect,
+	type MultiSelect,
+	type MultiSelectParams
+} from './multiSelect';
+
+export {
+	default as Form,
+	type FormFields,
+	type FormParams,
+	type FormSubmitAction,
+	type FormSubmitCallback,
+	type FormValues
+} from './Form';
+
 export {
 	email,
 	length,


### PR DESCRIPTION
Lo que dice el título. Básicamente los nuevos tipos exportados son `FormSubmitAction`, `FormFields` y `FormSubmitCallback`, el resto creo que estaban todos exportados ya (salvo los de uso interno).