### PR TITLE
Improve type safety

### DIFF
--- a/src/Form/types.ts
+++ b/src/Form/types.ts
@@ -1,15 +1,21 @@
-import Field from '../Field';
+import type Field from '../Field';
 import type Form from '.';
 
-export type FormSubmitCallback = ( form: Form ) => void | Promise<void>;
-export type FormSubmitAction = ( form: Form ) => Promise<void>;
+export type FormFields<ValueTypes, KeyTypes extends PropertyKey = PropertyKey>
+	= Record<KeyTypes, Field<ValueTypes>>;
 
-export interface FormParams {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	fields: Record<string, Field<any>>,
-	onSubmit?: FormSubmitCallback
+export type FormValues<F, K extends keyof F> = Record<K, unknown>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type FormSubmitCallback<T extends FormFields<any>>
+	= ( form: Form<T> ) => void | Promise<void>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type FormSubmitAction<T extends FormFields<any>>
+	= ( form: Form<T> ) => Promise<unknown>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface FormParams<T extends FormFields<any, keyof T>> {
+	fields: T,
+	onSubmit?: FormSubmitCallback<T>
 }
-
-export type FormFields = Record<string, Field<unknown>>;
-
-export type FormValues = Record<string, unknown>;

--- a/src/Form/utils.ts
+++ b/src/Form/utils.ts
@@ -1,13 +1,12 @@
 import { mapValues } from 'lodash';
-import type Form from '.';
-import { FormFields, FormSubmitAction, FormSubmitCallback } from './types';
+import { FormFields } from './types';
 
-export function wrapInAsyncAction( onSubmit: FormSubmitCallback ) {
-	return (
-		( form: Form ) => Promise.resolve( onSubmit( form ) )
-	) as FormSubmitAction;
+export function wrapInAsyncAction<T>( onSubmit: ( param: T ) => unknown | Promise<unknown> ) {
+	return ( param: T ) => Promise.resolve( onSubmit( param ) );
 }
 
-export function valuesOf( fields: FormFields ) {
+export function valuesOf<V, F extends FormFields<V>>(
+	fields: F
+): { [K in keyof F]: F[K]['value'] } {
 	return mapValues( fields, field => field.value );
 }

--- a/tests/Form.test.ts
+++ b/tests/Form.test.ts
@@ -1,7 +1,7 @@
 import ManualField from '../src/ManualField';
 import TestField from './support/TestField';
-import Form, { FormParams } from '../src/Form';
-import { invalid, valid } from '../src/validators';
+import Form from '../src/Form';
+import { invalid, valid } from '../src';
 
 describe( 'Form', () => {
 	const required = ( value: string ) => (
@@ -53,7 +53,7 @@ describe( 'Form', () => {
 
 	const onSubmit = jest.fn( () => Promise.resolve() );
 
-	const createForm = ( params?: Partial<FormParams> ) => new Form( {
+	const createForm = ( params?: Partial<ConstructorParameters<typeof Form>[0]> ) => new Form( {
 		fields: {
 			email: new TestField( fields.email ),
 			password: new TestField( fields.password ),
@@ -65,8 +65,8 @@ describe( 'Form', () => {
 		...params
 	} );
 
-	const createFormAndMakeItValid = ( params?: Partial<FormParams> ) => {
-		const form = createForm( params );
+	const createFormAndMakeItValid = () => {
+		const form = createForm();
 
 		form.field<TestField>( 'password' ).change( 'validpass' );
 		form.field<TestField>( 'passwordConfirmation' ).change( 'validpass' );


### PR DESCRIPTION
Agregue un tipado más estricto, con esto metodos como `fields` y `values` van a devolver bien el tipo de cada campo. Ademas el onSubmit queda bien tipado y ya no debería hacer falta hacer casteos al usar la librería 

<img width="746" alt="image" src="https://github.com/amalgamaco/mobx-form/assets/32112783/5ec58002-71e6-4960-896e-00d810ae2488">


Closes #22 
